### PR TITLE
Update 2.Selenium_Yahoo_Stock.py

### DIFF
--- a/3.Selenium/2.Selenium_Yahoo_Stock.py
+++ b/3.Selenium/2.Selenium_Yahoo_Stock.py
@@ -47,6 +47,9 @@ def main():
     print(tradeDate)
 
     nextButtonXpath = '//span[contains(text(),"載入更多")]/parent::*/parent::button'
+    #新增CloseAD,以避免64行及小螢幕出現無法偵測的問題
+    closeAD = wd.find_element(By.XPATH, '//button[@class="Fxs(0) H(24px) B(n) Mt(20px) P(0) As(fs)"]')
+    closeAD.click()
     #持續點擊「載入更多」
     while wd.find_element(By.XPATH, nextButtonXpath):
         # 等待元素可被點擊


### PR DESCRIPTION
程式爬取時
有時候會按到VIP AD的button
到最後會出現Error on 64 line:(`wd.execute_script("arguments[0].scrollIntoView()", element)`)
`Exception has occurred: StaleElementReferenceException
Message: stale element reference: element is not attached to the page document`
故新增兩行程式碼
在開始爬取前先關閉掉VIP AD,可避免這個狀況出現
![螢幕擷取畫面 2023-05-01 222135](https://user-images.githubusercontent.com/48470510/235466365-aaff4690-635f-4b56-b515-fd5c44c6f44a.png)
